### PR TITLE
feat: show average rating using star component on video card

### DIFF
--- a/app/components/shared/VideoContent.tsx
+++ b/app/components/shared/VideoContent.tsx
@@ -5,6 +5,14 @@ import StarRatingBasic from "~/components/commerce-ui/star-rating-basic";
 import type { ResponseVideo } from "~/features/video/type";
 
 export default function VideoContent({ video }: { video: ResponseVideo }) {
+  const { reviews } = video;
+  const totalReview = reviews.length;
+  const averageRating =
+    reviews?.length > 0
+      ? reviews.map((review) => review.rating).reduce((a, b) => a + b, 0) /
+        reviews.length
+      : 0;
+
   return (
     <li className="bg-neutral-900/60 rounded-lg overflow-hidden m-2">
       <Link to={`/watch/${video.id}`} className="block">
@@ -21,17 +29,15 @@ export default function VideoContent({ video }: { video: ResponseVideo }) {
           <div className="flex justify-between items-center">
             <span className="flex items-center gap-2 text-[15px]">
               <Icon icon="fa-solid:comment-alt" className="text-[16px]" />
-              <span>
-                {video?.reviews.length > 0 ? video?.reviews.length : 0}
-              </span>
+              <span>{totalReview}</span>
             </span>
 
-            {/* <StarRatingBasic
-              value= {3}
+            <StarRatingBasic
+              value={Math.floor(averageRating)}
               maxStars={5}
               readOnly={true}
               className="p-2"
-            /> */}
+            />
           </div>
           <p
             className="text-[#888888] overflow-hidden text-ellipsis"

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -42,7 +42,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
       <section className="">
         <div className="container mx-auto py-12">
           <div className="mt-8">
-            <ul className="grid grid-cols-4 gap-4">
+            <ul className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
               {videos.map((video) => (
                 <VideoContent key={video.id} video={video} />
               ))}


### PR DESCRIPTION
### Overview
- Menampilkan **average rating** dari review dalam bentuk bintang (menggunakan `StarRatingBasic`) di komponen video card.
- Jika tidak ada review, default rating adalah `0`.
- Pembulatan rating menggunakan `Math.floor()` untuk menghindari visual misleading dari desimal.

### Contoh:
- 2 review: 2 dan 3 → average = 2.5 → dibulatkan jadi 2 → tampil 2 bintang
- 3 review dengan rating: 4, 4, 5 → average = 4.33 → dibulatkan jadi 4 → tampil 4 bintang

### Related
- Tidak ada perubahan pada backend/API
- Komponen `StarRatingBasic` masih menggunakan full-star (tidak mendukung half-star)

> Contoh tampilan video card dengan average rating
![image](https://github.com/user-attachments/assets/2d37bbd1-967f-49f7-ae24-590334d87c0a)


