### PR TITLE
Feat/load more pagination

### DIFF
--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -15,7 +15,7 @@ export function meta({}: Route.MetaArgs) {
   ];
 }
 
-const DEFAULT_LIMIT = 8;
+const DEFAULT_LIMIT = 6;
 
 export async function loader({ request }: Route.LoaderArgs) {
   const url = new URL(request.url);
@@ -53,7 +53,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
       <section className="">
         <div className="container mx-auto py-12">
           <div className="mt-8">
-            <ul className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
               {videos.map((video) => (
                 <VideoContent key={video.id} video={video} />
               ))}


### PR DESCRIPTION
### Overview:
- Added a "Load More" feature using server-side cumulative pagination.
- Videos are fetched based on the `limit` query parameter. It starts at 8 and increases by 8 each time the user clicks the Load More button.

### How It Works:
1. On initial page load, the loader fetches the first 6 videos from the API (`offset=0&limit=6`).
2. When the user clicks "Load More", the `limit` increases (e.g., to 12), and React Router re-triggers the loader to fetch videos up to that new limit.
3. The scroll position is preserved between requests, so the user stays at the same spot on the page.