### PR TITLE
Improve error handling on login and register pages

### DIFF
--- a/app/components/ui/alert.tsx
+++ b/app/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "~/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -80,10 +80,10 @@ export default function LoginRoute({
       {error && (
         <div className="error">
           <div className="w-full max-w-sm md:max-w-sm md:-mt-14 mb-3">
-            <Alert variant="destructive">
+            <Alert className="bg-red-400 text-white">
               <AlertCircle className="h-4 w-4" />
               <AlertTitle>Login Failed</AlertTitle>
-              <AlertDescription>
+              <AlertDescription className="text-white">
                 Invalid username or password. Please try again.
               </AlertDescription>
             </Alert>

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,7 +1,9 @@
 import { useForm } from "@conform-to/react";
 import { parseWithZod } from "@conform-to/zod";
 import { Label } from "@radix-ui/react-label";
+import { AlertCircle } from "lucide-react";
 import { data, Form, Link, redirect } from "react-router";
+import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import { Input } from "~/components/ui/input";
@@ -38,23 +40,25 @@ export async function action({ request }: Route.ClientActionArgs) {
   });
   if (submission.status !== "success") return submission.reply();
 
-  const user = await auth.login(submission.value);
+  try {
+    const user = await auth.login(submission.value);
 
-  if (!user) {
-    session.flash("error", "Invalid username/password");
-    // Redirect back to the login page with errors.
-    return redirect("/login", {
+    session.set("userId", user.id);
+    session.set("accessToken", user.accessToken);
+    session.set("refreshToken", user.refreshToken);
+
+    return redirect("/dashboard", {
       headers: { "Set-Cookie": await commitSession(session) },
     });
+  } catch (error: unknown) {
+    session.flash("error", "Invalid username/password");
+
+    return redirect("/login", {
+      headers: {
+        "Set-Cookie": await commitSession(session),
+      },
+    });
   }
-
-  session.set("userId", user.id);
-  session.set("accessToken", user.accessToken);
-  session.set("refreshToken", user.refreshToken);
-
-  return redirect("/dashboard", {
-    headers: { "Set-Cookie": await commitSession(session) },
-  });
 }
 
 export default function LoginRoute({
@@ -73,7 +77,19 @@ export default function LoginRoute({
 
   return (
     <div className="flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
-      {error ? <div className="error">{error}</div> : null}
+      {error && (
+        <div className="error">
+          <div className="w-full max-w-sm md:max-w-sm md:-mt-14 mb-3">
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Login Failed</AlertTitle>
+              <AlertDescription>
+                Invalid username or password. Please try again.
+              </AlertDescription>
+            </Alert>
+          </div>
+        </div>
+      )}
 
       <div className="w-full max-w-sm md:max-w-sm">
         <div className="flex flex-col gap-6">

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -78,16 +78,14 @@ export default function LoginRoute({
   return (
     <div className="flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
       {error && (
-        <div className="error">
-          <div className="w-full max-w-sm md:max-w-sm md:-mt-14 mb-3">
-            <Alert className="bg-red-400 text-white">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>Login Failed</AlertTitle>
-              <AlertDescription className="text-white">
-                Invalid username or password. Please try again.
-              </AlertDescription>
-            </Alert>
-          </div>
+        <div className="w-full max-w-sm md:max-w-sm md:-mt-14 mb-3">
+          <Alert className="bg-red-400 text-white">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Login Failed</AlertTitle>
+            <AlertDescription className="text-white">
+              Invalid username or password. Please try again.
+            </AlertDescription>
+          </Alert>
         </div>
       )}
 

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -79,10 +79,10 @@ export default function RegisterRoute({
     <div className="flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
       {error && (
         <div className="w-full max-w-sm md:max-w-sm md:-mt-7 mb-3">
-          <Alert variant="destructive">
+          <Alert className="bg-red-400 text-white">
             <AlertCircle className="h-4 w-4" />
             <AlertTitle>Register Failed</AlertTitle>
-            <AlertDescription>{error}</AlertDescription>
+            <AlertDescription className="text-white">{error}</AlertDescription>
           </Alert>
         </div>
       )}


### PR DESCRIPTION
## Changes
- Refactored `login` and `register` actions to handle errors more gracefully.
- Improved user feedback with descriptive alerts instead of default React Router errors or app crashes.
- In login:
  - Now catches errors and shows a generic "Invalid username/password" alert.
- In register:
  - Displays specific error messages from the backend if available (e.g., 400 or 500 responses).

## Why
- Previously, errors on login/register caused the app to crash or showed an unhelpful generic error.
- Now users are clearly informed about what went wrong, improving UX and stability.

## Preview
- **Register page**: Shows backend error messages like "User with this email already exists" or "User with this username already exists".
  > ![image](https://github.com/user-attachments/assets/ea5e85fb-eafd-439a-86c0-e6bc51b33855)

- **Login page**: Displays alert on invalid credentials.
  > ![image](https://github.com/user-attachments/assets/84b07561-6f43-4e7d-95cf-09472c986ffd)

## Notes
- Currently, login error message is generic for any error (`Invalid username/password`). If needed, we can improve this later to show more specific messages (e.g., network issue vs invalid credentials).
- Feel free to suggest better UX for displaying these alerts.





---