### PR TITLE
feat: edit review

### DIFF
--- a/app/features/review/type.ts
+++ b/app/features/review/type.ts
@@ -7,3 +7,7 @@ export type ResponseReviews =
 // /videos/:videoId/reviews
 
 export type ResponseReview = ElementType<ResponseReviews>;
+
+
+export type ResponseReviewsIdentifier =
+  paths["/reviews/{identifier}"]["get"]["responses"][200]["content"]["application/json"];

--- a/app/routes/review-video.tsx
+++ b/app/routes/review-video.tsx
@@ -1,7 +1,7 @@
 import { parseWithZod } from "@conform-to/zod";
 import { Label } from "@radix-ui/react-label";
 import ky from "ky";
-import { useState } from "react";
+import { use, useEffect, useState } from "react";
 import { Form, redirect, useNavigate } from "react-router";
 import StarRatingBasic from "~/components/commerce-ui/star-rating-basic";
 import { Card } from "~/components/ui/card";
@@ -11,7 +11,7 @@ import { serverApiUrl } from "~/lib/api-server";
 import { reviewFormSchema } from "~/lib/review";
 import { getSession } from "~/lib/sessions";
 import type { Route } from "./+types/review-video";
-import type { ResponseReviews } from "~/features/review/type";
+import type { ResponseReviews, ResponseReviewsIdentifier } from "~/features/review/type";
 
 export function meta({ data }: Route.MetaArgs) {
   return [
@@ -27,8 +27,12 @@ export function meta({ data }: Route.MetaArgs) {
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+
   const session = await getSession(request.headers.get("Cookie"));
   const currentUserId = session.get("userId") || null;
+  const reviewId = url.searchParams.get("review") || null;
+
   if (!session.has("userId")) return redirect("/login");
 
   const { videoId } = params;
@@ -40,19 +44,31 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     .get(`${serverApiUrl}/reviews?videoId=${video.id}`)
     .json<ResponseReviews>();
 
+  let reviewedData = null;
+
   const isUserReview = currentUserId
     ? reviews.some((review) => review.userId === currentUserId)
     : false;
 
-  if (isUserReview) {
+  if (isUserReview && !reviewId) {
     return redirect(`/watch/${videoId}`);
   }
 
-  return { video };
+  if (reviewId) {
+    reviewedData = await ky
+      .get(`${serverApiUrl}/reviews/${reviewId}`)
+      .json<ResponseReviewsIdentifier>();
+  }
+
+  console.log("reviewedData", reviewedData);
+
+  return { video, reviewedData };
 }
 
 export async function action({ params, request }: Route.ActionArgs) {
   const session = await getSession(request.headers.get("Cookie"));
+
+  console.log(request.method);
 
   if (!session.has("userId")) {
     return redirect("/login");
@@ -66,21 +82,47 @@ export async function action({ params, request }: Route.ActionArgs) {
   if (review.status !== "success") return { error: "Failed to add new review" };
   const { videoId } = params;
 
-  const submittedReview = await ky
-    .post(`${serverApiUrl}/reviews/${videoId}`, {
-      credentials: "include",
-      headers: { Authorization: `Bearer ${session.get("accessToken")}` },
-      json: review.value,
-    })
-    .json();
+  if (request.method === 'POST') {
+    const submittedReview = await ky
+      .post(`${serverApiUrl}/reviews/${videoId}`, {
+        credentials: "include",
+        headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+        json: review.value,
+      })
+      .json();
+  }
+
+  if (request.method === 'PATCH') {
+    const reviewId = formData.get("reviewId");
+
+    console.log(review.value)
+
+    await ky
+      .patch(`${serverApiUrl}/reviews/${reviewId}`, {
+        credentials: "include",
+        headers: { Authorization: `Bearer ${session.get("accessToken")}` },
+        json: review.value,
+      })
+      .json();
+  }
 
   return redirect(`/watch/${videoId}`);
 }
 
 export default function NewReviewRoute({ loaderData }: Route.ComponentProps) {
-  const { video } = loaderData;
+  const { video, reviewedData } = loaderData;
   const navigate = useNavigate();
   const [rating, setRating] = useState(0);
+
+  // if ( reviewedData && reviewedData.content.rating) {
+  //   setRating(reviewedData.content.rating);
+  // }
+
+  useEffect(() => {
+    if (reviewedData && reviewedData.content.rating) {
+      setRating(reviewedData.content.rating);
+    }
+  }, []);
 
   return (
     <div className="flex min-h-svh flex-col items-center justify-center p-6 md:p-10">
@@ -98,11 +140,14 @@ export default function NewReviewRoute({ loaderData }: Route.ComponentProps) {
               />
               <h1 className="p-2 text-xl font-bold">{video.title}</h1>
 
-              <Form method="post">
+              <Form method={reviewedData ? "patch" : "post"}>
+                <input type="hidden" name="reviewId" value={reviewedData?.content?.id} />
+
                 <div className="flex flex-col">
                   <Label className="m-2">Review</Label>
                   <TextArea
                     name="text"
+                    defaultValue= {reviewedData?.content?.text || ""}
                     placeholder="Write your review..."
                     className="bg-white rounded-md m-2 py-1 px-3 placeholder:text-gray-500 text-slate-800"
                   />

--- a/app/routes/review-video.tsx
+++ b/app/routes/review-video.tsx
@@ -130,7 +130,7 @@ export default function NewReviewRoute({ loaderData }: Route.ComponentProps) {
         <Card className="bg-neutral-900/60">
           <div className="py-3 px-6">
             <div className="flex flex-row justify-between mb-4">
-              <h1 className="text-2xl font-bold">Submit Review</h1>
+              <h1 className="text-2xl font-bold">{reviewedData ? "Edit" : "Submit"} Review</h1>
             </div>
             <div className="grid grid-cols-1">
               <img
@@ -168,7 +168,7 @@ export default function NewReviewRoute({ loaderData }: Route.ComponentProps) {
                     type="submit"
                     className="bg-sky-400 hover:bg-sky-500 rounded-full px-3 py-2 m-2 text-black font-medium"
                   >
-                    Submit
+                    {reviewedData ? "Edit" : "Submit"}
                   </button>
                   <button
                     type="button"

--- a/app/routes/watch-video.tsx
+++ b/app/routes/watch-video.tsx
@@ -56,6 +56,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   // const reviews = await ky
   // .get(`${serverApiUrl}/videos/${videoId}/reviews`)
   // .json<ResponseReviews>();
+  console.log(reviews)
 
   // TODO: Fix typing
   const isUserReview = userId
@@ -223,8 +224,16 @@ export default function VideoDetailsRoute({
                 </div>
                 <p className="whitespace-pre-wrap text-white">{review.text}</p>
                 {userId === review.userId && (
-                  <Form method="delete" className="flex justify-end mt-4">
+                  <Form method="delete" className="flex justify-end mt-4 gap-2.5">
                     <input type="hidden" name="videoId" value={review.id} />
+                    <Link to={`/review/${video.id}?review=${review.id}`}>
+                      <Icon
+                        icon="mdi:edit-box"
+                        className="text-white text-lg hover:text-blue-500 transition-colors duration-150"
+                        width={24}
+                        height={24}
+                      />
+                    </Link>
                     <button type="submit" value={review.id}>
                       <Icon
                         icon="mdi:trash-can-outline"
@@ -235,6 +244,7 @@ export default function VideoDetailsRoute({
                     </button>
                   </Form>
                 )}
+
               </div>
             ))}
           </div>

--- a/app/routes/watch-video.tsx
+++ b/app/routes/watch-video.tsx
@@ -53,11 +53,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     .get(`${serverApiUrl}/reviews?videoId=${video.id}`)
     .json<ResponseReviews>();
 
-  // const reviews = await ky
-  // .get(`${serverApiUrl}/videos/${videoId}/reviews`)
-  // .json<ResponseReviews>();
-  console.log(reviews)
-
   // TODO: Fix typing
   const isUserReview = userId
     ? reviews.some((review) => review.userId === userId)


### PR DESCRIPTION
This pull request introduces functionality for editing reviews, improves type definitions, and refines the user experience for review-related routes. The most important changes include adding support for PATCH requests to update reviews, enhancing the loader logic to fetch individual review data, and updating the UI to prefill review forms for editing.

### Review Editing Functionality:

* Added support for PATCH requests in the `action` function of `app/routes/review-video.tsx`, enabling users to update existing reviews. This includes sending the updated review data to the server and handling the `reviewId` parameter.
* Updated the review form to dynamically switch between POST and PATCH methods based on whether a review is being edited. The form now includes a hidden input field for `reviewId` and pre-fills the text area with existing review content if available.

### Loader Enhancements:

* Modified the `loader` function in `app/routes/review-video.tsx` to fetch individual review data when a `reviewId` query parameter is present. This data is used to populate the review form for editing. [[1]](diffhunk://#diff-992a452cc8153ddcc498447a5b2f0595381624e45cdf4fc2466291bb810248adR47-R72) [[2]](diffhunk://#diff-992a452cc8153ddcc498447a5b2f0595381624e45cdf4fc2466291bb810248adR30-R35)

### Type Definitions:

* Introduced a new `ResponseReviewsIdentifier` type in `app/features/review/type.ts` to handle the structure of individual review responses.
* Updated imports in `app/routes/review-video.tsx` to include the new type for better type safety.

### UI and Navigation Improvements:

* Added an "Edit" button in `app/routes/watch-video.tsx` that links to the review editing page for the corresponding review.
* Used `useEffect` in `app/routes/review-video.tsx` to initialize the rating state when editing an existing review.

### Debugging Logs:

* Added temporary `console.log` statements in multiple locations for debugging purposes (e.g., in `loader` and `action` functions). These should be removed before deploying to production. [[1]](diffhunk://#diff-992a452cc8153ddcc498447a5b2f0595381624e45cdf4fc2466291bb810248adR47-R72) [[2]](diffhunk://#diff-992a452cc8153ddcc498447a5b2f0595381624e45cdf4fc2466291bb810248adR85-R126) [[3]](diffhunk://#diff-43c9eb58d64bbb283a5cd417ac8e104690490e0f5a1b57ca363c746d173982bdR59)